### PR TITLE
Check for the options object

### DIFF
--- a/vue-moment.js
+++ b/vue-moment.js
@@ -10,7 +10,7 @@ module.exports = {
 			},
 		});
 
-		if (options.moment) {
+		if (options && options.moment) {
 			moment = options.moment
 		}
 


### PR DESCRIPTION
Without this check we would have to pass an empty object as the second param during the plugin initialization.