### PR TITLE
work with vuejs 1.0

### DIFF
--- a/vue-moment.js
+++ b/vue-moment.js
@@ -26,7 +26,7 @@ module.exports = {
 			if (!date.isValid()) return '';
 
 			function parse() {
-				var args = Array.prototype.slice.call(arguments).map(function(str) { return str.replace(/^("|')|("|')$/g, ''); }),
+				var args = Array.prototype.slice.call(arguments),
 					method = args.shift();
 
 				switch (method) {


### PR DESCRIPTION
In VueJS 1.0 and beyond, arguments are expanded from the scope, so strings are passed as strings and objects such as dates are passed in directly.

If passing a date object to this method, the quote removal (which is now incorrect behavior), will blow up.

I would have just checked for string vs object, but removing quotes from the string is actually bad as well, as VueJS 1.0 now passes in post-parsed strings properly.