### PR TITLE
Fix for "moment is not defined" in strict mode

### DIFF
--- a/vue-moment.js
+++ b/vue-moment.js
@@ -40,8 +40,8 @@ module.exports = {
 			}
 
 			function parse() {
-				var args = Array.prototype.slice.call(arguments);
-				method = args.shift();
+				var args = Array.prototype.slice.call(arguments),
+					method = args.shift();
 
 				switch (method) {
 					case 'add':


### PR DESCRIPTION
In strict mode, no access to global variables is permitted, so attempting to assign to an undefined variable results in an error being thrown.