### PR TITLE
Temporarily set moment version to 2.18.1 due to 2.19 instability

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/brockpetrie/vue-moment#readme",
   "dependencies": {
-    "moment": "^2.11.1"
+    "moment": "2.18.1"
   },
   "peerDependencies": {
     "vue": ">=1.x.x"


### PR DESCRIPTION
Moment.js is dealing with `./locale` issues (https://github.com/moment/moment/issues/4216), which makes it unusable. For now, can we set the version to 2.18.1, then revert once the issues are fixed?

