### PR TITLE
Moment timezone

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "jest": "^21.2.1",
     "jest-serializer-vue": "^0.2.0",
     "jest-vue": "^0.8.1",
+    "moment-timezone": "^0.5.14",
     "vue": "^2.5.2"
   },
   "jest": {

--- a/tests/vue-moment.spec.js
+++ b/tests/vue-moment.spec.js
@@ -1,8 +1,10 @@
 import Vue from 'vue/dist/vue'
 import VueMoment from '../vue-moment'
-import moment from 'moment'
+import moment from 'moment-timezone'
 
-Vue.use(VueMoment)
+Vue.use(VueMoment, {
+    moment,
+})
 
 const now = moment()
 const tomorrow = moment().add(1, 'day')
@@ -91,6 +93,14 @@ describe('VueMoment', () => {
                 vm.args = ['subtract', '1 day']
                 vm.$nextTick(() => {
                     expect(vm.$el.textContent).toContain(now.clone().subtract(1, 'days').toISOString())
+                    done()
+                })
+            }) 
+
+            it('timezone', (done) => {
+                vm.args = ['timezone', 'America/Los_Angeles', '']
+                vm.$nextTick(() => {
+                    expect(vm.$el.textContent).toContain(now.clone().tz('America/Los_Angeles').format())
                     done()
                 })
             }) 

--- a/vue-moment.js
+++ b/vue-moment.js
@@ -142,6 +142,12 @@ module.exports = {
 						date = date.calendar(referenceTime);
 						break;
 
+					case 'timezone':
+						// Mutates the original moment by converting to a new timezone.
+						// https://momentjs.com/timezone/docs/#/using-timezones/converting-to-zone/
+						date = date.tz(args.shift());
+						break;
+
 					default:
 						// Format
 						// Formats a date by taking a string of tokens and replacing them with their corresponding values.

--- a/yarn.lock
+++ b/yarn.lock
@@ -2162,7 +2162,13 @@ minimist@~0.0.1:
   dependencies:
     minimist "0.0.8"
 
-moment@^2.11.1:
+moment-timezone@^0.5.14:
+  version "0.5.14"
+  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.14.tgz#4eb38ff9538b80108ba467a458f3ed4268ccfcb1"
+  dependencies:
+    moment ">= 2.9.0"
+
+"moment@>= 2.9.0", moment@^2.11.1:
   version "2.19.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.19.1.tgz#56da1a2d1cbf01d38b7e1afc31c10bcfa1929167"
 


### PR DESCRIPTION
Hey man,

I was testing how nicely vue-moment integrates with moment-timezone for #43 and I thought I would go one step further and add a new filter to convert the current timezone.

As moment-timezone appears to be a superset of moment, I have changed our tests to pass moment-timezone through to our plugin, which puts some coverage on that feature too.

## Usage
In the users main.js they can import `moment-timezone` and pass that through to the plugin
```js
// main.js
import moment from 'moment-timezone'

Vue.use(VueMoment, {
    moment,
})
```
this will allow the `.tz()` method to become available in the vue components
``` js
// app.vue
this.$moment.tz('America/Los_Angeles')
```
and here is an example of using the new timezone filter in the template...

```html
<span>{{ date | moment('timezone', 'America/Los_Angeles', 'LLLL ss')}}</span>
```

What do you think?

Cheers
Brock