### PR TITLE
Treat Number input as Unix time

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-moment",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Handy Moment.js filters for your Vue.js project",
   "main": "vue-moment.js",
   "scripts": {

--- a/readme.md
+++ b/readme.md
@@ -5,13 +5,13 @@ Handy [Moment.js](http://www.momentjs.com) filters for your [Vue.js](http://vuej
 
 ## Installation
 
-Install via NPM and 
+Install via NPM...
 
 ```sh
 $ npm install vue-moment
 ```
 
-Require the plugin like so:
+...and require the plugin like so:
 
 ```js
 Vue.use(require('vue-moment'));
@@ -29,7 +29,7 @@ Simply set `moment` as the filtering function and you're good to go. At least on
 
 ## Passing Your Date
 
-Moment.js expects your input to be either: a valid ISO 8601 formatted string (see <http://momentjs.com/docs/#/parsing/string/>), a valid `Date` object, or a date string with an accompanying format pattern (i.e. when you know the format of the date input). For the latter, `vue-moment` allows you to pass your date and format pattern(s) as an array, like such:
+Moment.js expects your input to be either: a valid ISO 8601 formatted string (see <http://momentjs.com/docs/#/parsing/string/>), a valid `Date` object, a Unix timestamp (must be passed as a Number), or a date string with an accompanying format pattern (i.e. when you know the format of the date input). For the latter, `vue-moment` allows you to pass your date and format pattern(s) as an array, like such:
 
 ```html
 <span>{{ [ someDate, "MM.DD.YY" ] | moment("dddd, MMMM Do YYYY") }}</span>

--- a/vue-moment.js
+++ b/vue-moment.js
@@ -26,6 +26,9 @@ module.exports = {
 				// Format pattern will accept an array of potential formats to parse against.
 				// Date string should be at [0], format pattern(s) should be at [1]
 				date = moment(string = input[0], formats = input[1], true);
+			} else if (typeof input === 'number') {
+				// If input is an integer, assume it's a Unix timestamp.
+				date = moment.unix(input);
 			} else {
 				// Otherwise, throw the input at moment and see what happens...
 				date = moment(input);


### PR DESCRIPTION
This makes it so when a user passes an input with type `Number`, we assume it's a Unix epoch and pass it through `moment.unix()`.

@BrockReece Can you think of any reasons why this might be a bad way to do this? I think we're fine, as the only problem I could think of is when a zero is passed in by mistake, but our falsey check correctly kills the filter in that case. Any situations you can think of where an input typed as Number and greater than zero would be faultily passed in?