### PR TITLE
Add Duration filter

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -61,7 +61,7 @@ For more information about `moment#format`, check out <http://momentjs.com/docs/
 
 ### from
 
-Display a moment in relative time, either from now or from a specified date.
+Display a Moment in relative time, either from now or from a specified date.
 
 **Default** (calculates from current time)
 
@@ -113,7 +113,7 @@ For more information about `moment#calendar`, check out <http://momentjs.com/doc
 
 ### add
 
-Mutates the original moment by adding time.
+Mutates the original Moment by adding time.
 
 ```html
 <span>{{ someDate | moment("add", "7 days") }}</span>
@@ -167,6 +167,44 @@ There's some built-in (and not thoroughly tested) support for chaining, like so:
 ```
 
 This would add 2 years and 8 months to the date, then subtract 3 hours, then format the resulting date.
+
+
+## Durations
+
+`vue-moment` also provides a `duration` filter that leverages Moment's ability to parse, manipulate and display durations of time. Durations should be passed as either: a String of a valid ISO 8601 formatted duration, a Number of milliseconds, an Array containing a number and unit of measurement (for passing a number other than milliseconds), or an Object of values (for when multiple different units of measurement are needed).
+
+```html
+<span>{{ 3600000 | duration('humanize') }}</span>
+<!-- "an hour" -->
+<span>{{ 'PT1800S' | duration('humanize') }}</span>
+<!-- "30 minutes" -->
+<span>{{ [35, 'days'] | duration('humanize', true) }}</span>
+<!-- "in a month" -->
+```
+
+This filter is purely a pass-through proxy to `moment.duration` methods, so pretty much all the functions outlined in their [docs](https://momentjs.com/docs/#/durations/) are callable.
+
+```html
+<span>{{ [-1, 'minutes'] | duration('humanize', true) }}</span>
+<!-- "a minute ago" -->
+<span>{{ { days: 10, months: 1 } | duration('asDays') }}</span>
+<!-- "40" -->
+<span>{{ 'P3D' | duration('as', 'hours') }}</span>
+<!-- "72" -->
+```
+
+For manipulating a duration by either subtraction or addition, first use the relevant filter option, then chain your duration display filter.
+
+```html
+<span>{{ [1, 'minutes'] | duration('subtract', 120000) | duration('humanize', true) }}</span>
+<!-- "a minute ago" -->
+<span>{{ [-10, 'minutes'] | duration('add', 'PT11M') | duration('humanize', true) }}</span>
+<!-- "in a minute" -->
+<span>{{ [2, 'years'] | duration('add', 1, 'year') | duration('humanize') }}</span>
+<!-- "3 years" -->
+```
+
+`duration` is for contextless lengths of time; for comparing 2 dates, use the `diff` method rather than hacking around with Moment durations. For more information about `moment#duration`, check out <https://momentjs.com/docs/#/durations/>.
 
 
 ## Configuration

--- a/tests/vue-moment.spec.js
+++ b/tests/vue-moment.spec.js
@@ -8,6 +8,7 @@ Vue.use(VueMoment, {
 
 const now = moment();
 const tomorrow = moment().add(1, 'day');
+const period = 'P1D';
 
 const vm = new Vue({
   template: '<div>{{ now | moment(...args) }}</div>',
@@ -17,6 +18,17 @@ const vm = new Vue({
       args: [
         'YYYY-MM-DD',
       ],
+    };
+  },
+}).$mount();
+
+const vmd = new Vue({
+  template: '<div>{{ period | duration(...args) | duration(...formatter) }}</div>',
+  data() {
+    return {
+      period,
+      args: [],
+      formatter: ['humanize', true],
     };
   },
 }).$mount();
@@ -34,6 +46,7 @@ describe('VueMoment', () => {
     it('sets locale', () => {
       vm.$moment.locale('fr');
       expect(vm.$moment.locale()).toEqual('fr');
+      vm.$moment.locale('en');
     });
   });
 
@@ -137,6 +150,54 @@ describe('VueMoment', () => {
         vm.args = ['add', '2 days', 'subtract', '1 day', 'YYYY-MM-DD'];
         vm.$nextTick(() => {
           expect(vm.$el.textContent).toContain(now.clone().add(1, 'days').format('YYYY-MM-DD'));
+          done();
+        });
+      });
+    });
+
+    describe('durations', () => {
+      afterEach(() => {
+        vmd.period = period;
+        vmd.args = [];
+        vmd.formatter = ['humanize', true];
+      });
+
+      it('simple humanize', (done) => {
+        vmd.$nextTick(() => {
+          expect(vmd.$el.textContent).toContain('in a day');
+          done();
+        });
+      });
+
+      it('add', (done) => {
+        vmd.args = ['add', 'P1D'];
+        vmd.$nextTick(() => {
+          expect(vmd.$el.textContent).toContain('in 2 days');
+          done();
+        });
+      });
+
+      it('subtract', (done) => {
+        vmd.args = ['subtract', 'P2D'];
+        vmd.$nextTick(() => {
+          expect(vmd.$el.textContent).toContain('a day ago');
+          done();
+        });
+      });
+
+      it('to string', (done) => {
+        vmd.period = [5, 'days'];
+        vmd.formatter = ['toISOString'];
+        vmd.$nextTick(() => {
+          expect(vmd.$el.textContent).toContain('P5D');
+          done();
+        });
+      });
+
+      it('getter', (done) => {
+        vmd.formatter = ['asHours'];
+        vmd.$nextTick(() => {
+          expect(vmd.$el.textContent).toContain('24');
           done();
         });
       });

--- a/vue-moment.js
+++ b/vue-moment.js
@@ -187,5 +187,36 @@ module.exports = {
 
       return date;
     });
+
+    Vue.filter('duration', (...args) => {
+      /*
+      * Basic pass-through filter for leveraging moment.js's ability
+      * to manipulate and display durations.
+      * https://momentjs.com/docs/#/durations/
+      */
+      args = Array.prototype.slice.call(args);
+      const input = args.shift();
+      const method = args.shift();
+
+      function createDuration(time) {
+        if (!Array.isArray(time)) time = [time];
+        const result = moment.duration(...time);
+        if (!result.isValid()) console.warn('Could not build a valid `duration` object from input.');
+        return result;
+      }
+      let duration = createDuration(input);
+
+      if (method === 'add' || method === 'subtract') {
+        // Generates a duration object and either adds or subtracts it
+        // from our original duration.
+        const durationChange = createDuration(args);
+        duration[method](durationChange);
+      } else if (duration && duration[method]) {
+        // This gives a full proxy to moment.duration functions.
+        duration = duration[method](...args);
+      }
+
+      return duration;
+    });
   },
 };


### PR DESCRIPTION
This adds a separate `duration` filter to interact with [Moment's duration functionality](https://momentjs.com/docs/#/durations/). Because durations are different than dates, I think it only makes sense to have the filters be separate.

@BrockReece Could you battle test this a bit and see if any issues pop up? In the meantime, going to work on adding some tests.