### PR TITLE
Added info on availability of this.$moment to the readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -190,10 +190,6 @@ console.log(Vue.moment().locale()) //es
 
 ## this.$moment
 
-`vue-moment` attaches the momentjs instance to your Vue app as `this.$moment`
-
-## this.$moment
-
 `vue-moment` attaches the momentjs instance to your Vue app as `this.$moment`. 
 
 This allows you to call [the static methods momentjs provides](https://momentjs.com/docs/#/i18n/listing-months-weekdays/).

--- a/readme.md
+++ b/readme.md
@@ -187,3 +187,16 @@ Vue.use(require('vue-moment'), {
 
 console.log(Vue.moment().locale()) //es
 ```
+
+## this.$moment
+
+`vue-moment` attaches the momentjs instance to your Vue app as `this.$moment`
+
+## this.$moment
+
+`vue-moment` attaches the momentjs instance to your Vue app as `this.$moment`. 
+
+This allows you to call [the static methods momentjs provides](https://momentjs.com/docs/#/i18n/listing-months-weekdays/).
+
+If you're using i18n, it allows you to change the locale globally by calling `this.$moment.locale(myNewLocale)`
+


### PR DESCRIPTION
Perhaps I'm thick, but it took me a while to figure out how I could change the moment locale globally.  
Or to put it differently, how I could call `locale()` on the momentjs instance.

Turns out it's available through `this.$moment` which is sort of obvious once you know it, but clearly not when you're not a seasoned JS developer.

So I've added this info to the readme, as I feel it's important to have this documented.