### PR TITLE
Guard null/undefined input

### DIFF
--- a/tests/vue-moment.spec.js
+++ b/tests/vue-moment.spec.js
@@ -59,7 +59,7 @@ describe('VueMoment', () => {
                     expect(vm.$el.textContent).toContain('a day ago')
                     done()
                 })
-            }) 
+            })
 
             it('remove prefix', (done) => {
                 vm.args = ['from', tomorrow, true]
@@ -67,7 +67,7 @@ describe('VueMoment', () => {
                     expect(vm.$el.textContent).toContain('a day')
                     done()
                 })
-            }) 
+            })
         })
 
         describe('calendar', () => {
@@ -77,7 +77,7 @@ describe('VueMoment', () => {
                     expect(vm.$el.textContent).toContain(now.calendar())
                     done()
                 })
-            }) 
+            })
         })
 
         describe('maths', () => {
@@ -87,7 +87,7 @@ describe('VueMoment', () => {
                     expect(vm.$el.textContent).toContain(now.clone().add(1, 'days').toISOString())
                     done()
                 })
-            }) 
+            })
 
             it('subtract', (done) => {
                 vm.args = ['subtract', '1 day']
@@ -95,7 +95,7 @@ describe('VueMoment', () => {
                     expect(vm.$el.textContent).toContain(now.clone().subtract(1, 'days').toISOString())
                     done()
                 })
-            }) 
+            })
 
             it('timezone', (done) => {
                 vm.args = ['timezone', 'America/Los_Angeles', '']
@@ -103,7 +103,7 @@ describe('VueMoment', () => {
                     expect(vm.$el.textContent).toContain(now.clone().tz('America/Los_Angeles').format())
                     done()
                 })
-            }) 
+            })
         })
 
         describe('chaining', () => {
@@ -113,35 +113,35 @@ describe('VueMoment', () => {
                     expect(vm.$el.textContent).toContain(now.clone().add(1, 'days').format('YYYY-MM-DD'))
                     done()
                 })
-            }) 
+            })
         })
     })
 
     describe('handle inputs', () => {
         beforeEach(() => {
-            global.console.warn = jest.fn()  
+            global.console.warn = jest.fn()
         })
 
         afterAll(() => {
             vm.now = moment()
-        }) 
+        })
 
         it('handles string', (done) => {
             vm.now = '2017-01-01'
             vm.args = ['YYYY-MM-DD']
             vm.$nextTick(() => {
                 expect(console.warn).not.toBeCalled()
-                expect(vm.$el.textContent).toContain('2017-01-01')                
+                expect(vm.$el.textContent).toContain('2017-01-01')
                 done()
             })
         })
-        
+
         it('handles object', (done) => {
             vm.now = {y: 2017, m: 1, d: 1}
             vm.args = ['YYYY-MM-DD']
             vm.$nextTick(() => {
                 expect(console.warn).not.toBeCalled()
-                expect(vm.$el.textContent).toContain('2017-01-01')                
+                expect(vm.$el.textContent).toContain('2017-01-01')
                 done()
             })
         })
@@ -151,7 +151,7 @@ describe('VueMoment', () => {
             vm.args = ['YYYY-MM-DD']
             vm.$nextTick(() => {
                 expect(console.warn).not.toBeCalled()
-                expect(vm.$el.textContent).toContain('2017-01-01')                
+                expect(vm.$el.textContent).toContain('2017-01-01')
                 done()
             })
         })
@@ -161,7 +161,7 @@ describe('VueMoment', () => {
             vm.args = ['YYYY-MM-DD']
             vm.$nextTick(() => {
                 expect(console.warn).not.toBeCalled()
-                expect(vm.$el.textContent).toContain('2017-01-01')                
+                expect(vm.$el.textContent).toContain('2017-01-01')
                 done()
             })
         })
@@ -169,11 +169,20 @@ describe('VueMoment', () => {
         it('handles undefined', (done) => {
             vm.now = undefined
             vm.$nextTick(() => {
-                expect(console.warn).toBeCalled()
+                expect(console.warn).not.toBeCalled()
+                expect(vm.$el.textContent).toBe('');
                 done()
             })
         })
-        
+
+        it('handles null', (done) => {
+            vm.now = null
+            vm.$nextTick(() => {
+                expect(console.warn).not.toBeCalled()
+                expect(vm.$el.textContent).toBe('');
+                done()
+            })
+        })
         it('handles invalid string', (done) => {
             vm.now = 'foo'
             vm.$nextTick(() => {

--- a/vue-moment.js
+++ b/vue-moment.js
@@ -1,7 +1,7 @@
 module.exports = {
 	install: function (Vue, options) {
 		var moment = options && options.moment ? options.moment : require('moment');
-		
+
 		Object.defineProperties(Vue.prototype, {
 			$moment: {
 				get: function() {
@@ -17,6 +17,9 @@ module.exports = {
 				input = args.shift(),
 				date;
 
+			// Guard: don't do anything if input is null or undefined
+			if (input == null) return;
+
 			if (Array.isArray(input) && typeof input[0] === 'string') {
 				// If input is array, assume we're being passed a format pattern to parse against.
 				// Format pattern will accept an array of potential formats to parse against.
@@ -30,9 +33,9 @@ module.exports = {
 				date = moment(input);
 			}
 
-			if (!input || !date.isValid()) {
+			if (!date.isValid()) {
 				// Log a warning if moment couldn't reconcile the input. Better than throwing an error?
-				console.warn('Could not build a valid `moment` object from input.');
+				console.warn('Could not build a valid `moment` object from input.', input);
 				return input;
 			}
 
@@ -99,7 +102,7 @@ module.exports = {
 
 						date = date.fromNow(removeSuffix);
 						break;
-						
+
 					case 'diff':
 
 						// Mutates the original moment by doing a difference with another date.


### PR DESCRIPTION
* If the input is `null` or `undefined` then the filter should just exit as though it hadn’t been called
* Only check if the date isValid at last (we already know there was input)
* If the input did not result in a valid date, include the input in the console warning
* Update the tests to ensure the output is blank if the input is `null`/`undefined`

Closes #75 (I think that is what most developers want)

(oops, sorry - just noticed my editor removed all trailing spaces. I can revert that if needed to merge this).
