### PR TITLE
Not warning for empty Dates

### DIFF
--- a/vue-moment.js
+++ b/vue-moment.js
@@ -36,8 +36,6 @@ module.exports = {
       }
 
       if (!input || !date.isValid()) {
-        // Log a warning if moment couldn't reconcile the input. Better than throwing an error?
-        console.warn('Could not build a valid `moment` object from input.');
         return input;
       }
 


### PR DESCRIPTION
This fixes a very strange behavior when you show a warm in the console passing an empty date.

Fixes #75 