### PR TITLE
Allow for numbers when passing an array of date & format

### DIFF
--- a/tests/vue-moment.spec.js
+++ b/tests/vue-moment.spec.js
@@ -253,6 +253,16 @@ describe('VueMoment', () => {
       });
     });
 
+    it('handles array', (done) => {
+      vm.now = [7, 'M'];
+      vm.args = ['MMMM'];
+      vm.$nextTick(() => {
+        expect(console.warn).not.toBeCalled();
+        expect(vm.$el.textContent).toContain('July');
+        done();
+      });
+    });
+
     it('handles Date object', (done) => {
       vm.now = new Date(2017, 0, 1);
       vm.args = ['YYYY-MM-DD'];

--- a/vue-moment.js
+++ b/vue-moment.js
@@ -17,10 +17,10 @@ module.exports = {
       const input = args.shift();
       let date;
 
-      if (Array.isArray(input) && typeof input[0] === 'string') {
+      if (Array.isArray(input) && ['string', 'number'].includes(typeof input[0])) {
         // If input is array, assume we're being passed a format pattern to parse against.
         // Format pattern will accept an array of potential formats to parse against.
-        // Date string should be at [0], format pattern(s) should be at [1]
+        // Date should be at [0], format pattern(s) should be at [1]
         date = moment(input[0], input[1], true);
       } else if (typeof input === 'number') {
         if (input.toString().length < 12) {


### PR DESCRIPTION
Prior to this, you could only pass a date string along with a format, e.g. `[ '1', 'M' ]`. This allows for passing a numbered date, e.g. `[ 1, 'M']`, which is valid according to moment.

Fixes #82.