### PR TITLE
Use import statements in doc

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -17,7 +17,10 @@ $ npm install vue-moment
 ...and require the plugin like so:
 
 ```js
-Vue.use(require('vue-moment'));
+import Vue from 'vue'
+import VueMoment from 'vue-moment'
+
+Vue.use(VueMoment);
 ```
 
 ## Usage


### PR DESCRIPTION
Propose using `import` statements in the docs.
We are having reports of the `require` statement no longer working.

Fixes #74 