### PR TITLE
Check that `$moment` property is not exists on Vue.prototype

### DIFF
--- a/vue-moment.js
+++ b/vue-moment.js
@@ -2,13 +2,15 @@ module.exports = {
   install(Vue, options) {
     const moment = options && options.moment ? options.moment : require('moment');
 
-    Object.defineProperties(Vue.prototype, {
-      $moment: {
-        get() {
-          return moment;
+    if (!Object.prototype.hasOwnProperty.call(Vue, '$moment')) {
+      Object.defineProperties(Vue.prototype, {
+        $moment: {
+          get() {
+            return moment;
+          },
         },
-      },
-    });
+      });
+    }
 
     Vue.moment = moment;
 


### PR DESCRIPTION
I would like to integrate with [@nuxtjs/moment](https://github.com/nuxt-community/moment-module), with this check this will be possible.

 See https://github.com/nuxt-community/moment-module/pull/26#issuecomment-555106093